### PR TITLE
Drop dependency on `rustc_version`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/srijs/rust-crc32fast"
 readme = "README.md"
 keywords = ["checksum", "crc", "crc32", "simd", "fast"]
 
-[build-dependencies]
-rustc_version = "0.2"
-
 [dev-dependencies]
 bencher = "0.1"
 quickcheck = { version = "0.6", default-features = false }

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,35 @@
-extern crate rustc_version;
+use std::env;
+use std::process::Command;
+use std::str;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
-    let version = rustc_version::version().unwrap();
+    let minor = match rustc_minor_version() {
+        Some(n) => n,
+        None => return,
+    };
 
-    if version >= (1, 27, 0).into() {
+    if minor >= 27 {
         println!("cargo:rustc-cfg=crc32fast_stdarchx86");
     }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    macro_rules! otry {
+        ($e:expr) => {
+            match $e {
+                Some(e) => e,
+                None => return None,
+            }
+        };
+    }
+    let rustc = otry!(env::var_os("RUSTC"));
+    let output = otry!(Command::new(rustc).arg("--version").output().ok());
+    let version = otry!(str::from_utf8(&output.stdout).ok());
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    otry!(pieces.next()).parse().ok()
 }


### PR DESCRIPTION
Unfortunately this has upstream bugs like Kimundi/rustc-version-rs#11
which make the output non-robust in the face of changing rustc's output,
so switch to a more flexible manual implementation.