### PR TITLE
Reduce `#[cfg]` duplication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/srijs/rust-crc32fast"
 readme = "README.md"
 keywords = ["checksum", "crc", "crc32", "simd", "fast"]
 
+[dependencies]
+cfg-if = "0.1"
+
 [dev-dependencies]
 bencher = "0.1"
 quickcheck = { version = "0.6", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@
 #[macro_use]
 extern crate quickcheck;
 
+#[macro_use]
+extern crate cfg_if;
+
 use std::fmt;
 use std::hash;
 

--- a/src/specialized/mod.rs
+++ b/src/specialized/mod.rs
@@ -1,42 +1,33 @@
-#[cfg(all(
-    crc32fast_stdarchx86,
-    any(ctarget_arch = "x86", target_arch = "x86_64")
-))]
-mod pclmulqdq;
-#[cfg(all(
-    crc32fast_stdarchx86,
-    any(ctarget_arch = "x86", target_arch = "x86_64")
-))]
-pub use self::pclmulqdq::State;
+cfg_if! {
+    if #[cfg(all(
+        crc32fast_stdarchx86,
+        any(ctarget_arch = "x86", target_arch = "x86_64")
+    ))] {
+        mod pclmulqdq;
+        pub use self::pclmulqdq::State;
+    } else {
+        #[derive(Clone)]
+        pub enum State {}
+        impl State {
+            pub fn new() -> Option<Self> {
+                None
+            }
 
-#[cfg(not(all(
-    crc32fast_stdarchx86,
-    any(ctarget_arch = "x86", target_arch = "x86_64")
-)))]
-#[derive(Clone)]
-pub enum State {}
-#[cfg(not(all(
-    crc32fast_stdarchx86,
-    any(ctarget_arch = "x86", target_arch = "x86_64")
-)))]
-impl State {
-    pub fn new() -> Option<Self> {
-        None
-    }
+            pub fn update(&mut self, _buf: &[u8]) {
+                match *self {}
+            }
 
-    pub fn update(&mut self, _buf: &[u8]) {
-        match *self {}
-    }
+            pub fn finalize(self) -> u32 {
+                match self{}
+            }
 
-    pub fn finalize(self) -> u32 {
-        match self{}
-    }
+            pub fn reset(&mut self) {
+                match *self {}
+            }
 
-    pub fn reset(&mut self) {
-        match *self {}
-    }
-
-    pub fn combine(&mut self, _other: u32, _amount: u64) {
-        match *self {}
+            pub fn combine(&mut self, _other: u32, _amount: u64) {
+                match *self {}
+            }
+        }
     }
 }


### PR DESCRIPTION
I've found that macros like `cfg_if!` can greatly reduce the `#[cfg]`
duplication problem and as this crate will likely inevitably grow more
uses I suspect it'll be nice to avoid having so many `#[cfg]` tags
everywhere!