### PR TITLE
Add `no_std` support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,10 @@ script:
     then
         rustup target add $TARGET
         cargo check --target $TARGET
+        cargo check --target $TARGET --no-default-features
         cargo check --tests --target $TARGET
     else
         cargo test --no-fail-fast
+        cargo check --no-default-features
         cargo test --no-fail-fast --release
     fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ bencher = "0.1"
 quickcheck = { version = "0.6", default-features = false }
 rand = "0.4"
 
+[features]
+default = ["std"]
+std = []
+
 [[bench]]
 name = "bench"
 harness = false

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ On top of that, every commit is tested using an address sanitizer in CI to catch
 
 Even though neither fuzzing not sanitization has revealed any safety bugs yet, please don't hesitate to file an issue if you run into any crashes or other unexpected behaviour.
 
+## `no_std`
+
+This library supports being built without the Rust `std` library, by depending on the [raw-cpuid](https://github.com/gz/rust-cpuid) library.
+
+Simply enable the `no_std` feature to build without `std`.
+
+
 ## License
 
 This project is licensed under either of

--- a/README.md
+++ b/README.md
@@ -49,10 +49,7 @@ Even though neither fuzzing not sanitization has revealed any safety bugs yet, p
 
 ## `no_std`
 
-This library supports being built without the Rust `std` library, by depending on the [raw-cpuid](https://github.com/gz/rust-cpuid) library.
-
-Simply enable the `no_std` feature to build without `std`.
-
+This library supports being built without the Rust `std` library. The optimized `x86` implementation will be unavailable since it requires OS support. To build the crate in a `no_std` context, disable the default `std` feature.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
 //! Calling the `Hasher::new` constructor at runtime will perform a feature detection to select the most
 //! optimal implementation for the current CPU feature set.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 #[deny(missing_docs)]
 #[cfg(test)]
 #[macro_use]
@@ -26,8 +28,11 @@ extern crate quickcheck;
 #[macro_use]
 extern crate cfg_if;
 
-use std::fmt;
-use std::hash;
+#[cfg(feature = "std")]
+use std as core;
+
+use core::fmt;
+use core::hash;
 
 mod baseline;
 mod combine;

--- a/src/specialized/pclmulqdq.rs
+++ b/src/specialized/pclmulqdq.rs
@@ -57,7 +57,7 @@ const K6: i64 = 0x1db710640;
 const P_X: i64 = 0x1DB710641;
 const U_PRIME: i64 = 0x1F7011641;
 
-#[cfg(feature = "use_std")]
+#[cfg(feature = "std")]
 unsafe fn debug(s: &str, a: arch::__m128i) -> arch::__m128i {
     if false {
         union A {
@@ -74,7 +74,7 @@ unsafe fn debug(s: &str, a: arch::__m128i) -> arch::__m128i {
     return a;
 }
 
-#[cfg(not(feature = "use_std"))]
+#[cfg(not(feature = "std"))]
 unsafe fn debug(_s: &str, a: arch::__m128i) -> arch::__m128i {
     a
 }

--- a/src/specialized/pclmulqdq.rs
+++ b/src/specialized/pclmulqdq.rs
@@ -1,7 +1,7 @@
 #[cfg(target_arch = "x86")]
-use std::arch::x86 as arch;
+use core::arch::x86 as arch;
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64 as arch;
+use core::arch::x86_64 as arch;
 
 #[derive(Clone)]
 pub struct State {
@@ -9,6 +9,12 @@ pub struct State {
 }
 
 impl State {
+    #[cfg(not(feature = "std"))]
+    pub fn new() -> Option<Self> {
+        None
+    }
+
+    #[cfg(feature = "std")]
     pub fn new() -> Option<Self> {
         if is_x86_feature_detected!("pclmulqdq")
             && is_x86_feature_detected!("sse2")
@@ -51,6 +57,7 @@ const K6: i64 = 0x1db710640;
 const P_X: i64 = 0x1DB710641;
 const U_PRIME: i64 = 0x1F7011641;
 
+#[cfg(feature = "use_std")]
 unsafe fn debug(s: &str, a: arch::__m128i) -> arch::__m128i {
     if false {
         union A {
@@ -65,6 +72,11 @@ unsafe fn debug(s: &str, a: arch::__m128i) -> arch::__m128i {
         println!();
     }
     return a;
+}
+
+#[cfg(not(feature = "use_std"))]
+unsafe fn debug(_s: &str, a: arch::__m128i) -> arch::__m128i {
+    a
 }
 
 #[target_feature(enable = "pclmulqdq", enable = "sse2", enable = "sse4.1")]


### PR DESCRIPTION
Hi @srijs,

very nice implementation you have here ! I added feature-based support for `no_std` using the `raw-cpuid` crate to provide CPU features information at runtime.

Not much to say, this PR is quite straightforward and should not change much !