### PR TITLE
Add support for AArch64 CRC32 instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rand = "0.4"
 [features]
 default = ["std"]
 std = []
+nightly = []
 
 [[bench]]
 name = "bench"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This crate contains multiple CRC32 implementations:
 
 - A fast baseline implementation which processes up to 16 bytes per iteration
 - An optimized implementation for modern `x86` using `sse` and `pclmulqdq` instructions
+- An optimized implementation for `aarch64` using `crc32` instructions
 
 Calling the `Hasher::new` constructor at runtime will perform a feature detection to select the most
 optimal implementation for the current CPU feature set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 //! optimal implementation for the current CPU feature set.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(feature = "nightly", target_arch = "aarch64"), feature(stdsimd, aarch64_target_feature))]
 
 #[deny(missing_docs)]
 #[cfg(test)]

--- a/src/specialized/aarch64.rs
+++ b/src/specialized/aarch64.rs
@@ -1,0 +1,85 @@
+use std::arch::aarch64 as arch;
+
+#[derive(Clone)]
+pub struct State {
+    state: u32,
+}
+
+impl State {
+    pub fn new() -> Option<Self> {
+        if is_aarch64_feature_detected!("crc") {
+            // SAFETY: The conditions above ensure that all
+            //         required instructions are supported by the CPU.
+            Some(Self { state: 0 })
+        } else {
+            None
+        }
+    }
+
+    pub fn update(&mut self, buf: &[u8]) {
+        // SAFETY: The `State::new` constructor ensures that all
+        //         required instructions are supported by the CPU.
+        self.state = unsafe { calculate(self.state, buf) }
+    }
+
+    pub fn finalize(self) -> u32 {
+        self.state
+    }
+
+    pub fn reset(&mut self) {
+        self.state = 0;
+    }
+
+    pub fn combine(&mut self, other: u32, amount: u64) {
+        self.state = ::combine::combine(self.state, other, amount);
+    }
+}
+
+// target_feature is necessary to allow rustc to inline the crc32* wrappers
+#[target_feature(enable = "crc")]
+pub unsafe fn calculate(crc: u32, data: &[u8]) -> u32 {
+    let mut c32 = !crc;
+    let (pre_quad, quads, post_quad) = data.align_to::<u64>();
+
+    c32 = pre_quad.iter().fold(c32, |acc, &b| arch::__crc32b(acc, b));
+
+    // unrolling increases performance by a lot
+    let mut quad_iter = quads.chunks_exact(8);
+    for chunk in &mut quad_iter {
+        c32 = arch::__crc32d(c32, chunk[0]);
+        c32 = arch::__crc32d(c32, chunk[1]);
+        c32 = arch::__crc32d(c32, chunk[2]);
+        c32 = arch::__crc32d(c32, chunk[3]);
+        c32 = arch::__crc32d(c32, chunk[4]);
+        c32 = arch::__crc32d(c32, chunk[5]);
+        c32 = arch::__crc32d(c32, chunk[6]);
+        c32 = arch::__crc32d(c32, chunk[7]);
+    }
+    c32 = quad_iter.remainder().iter().fold(c32, |acc, &q| arch::__crc32d(acc, q));
+
+    c32 = post_quad.iter().fold(c32, |acc, &b| arch::__crc32b(acc, b));
+
+    !c32
+}
+
+#[cfg(test)]
+mod test {
+    quickcheck! {
+        fn check_against_baseline(chunks: Vec<(Vec<u8>, usize)>) -> bool {
+            let mut baseline = super::super::super::baseline::State::new();
+            let mut aarch64 = super::State::new().expect("not supported");
+            for (chunk, mut offset) in chunks {
+                // simulate random alignments by offsetting the slice by up to 15 bytes
+                offset = offset & 0xF;
+                if chunk.len() <= offset {
+                    baseline.update(&chunk);
+                    aarch64.update(&chunk);
+                } else {
+                    baseline.update(&chunk[offset..]);
+                    aarch64.update(&chunk[offset..]);
+                }
+            }
+            aarch64.finalize() == baseline.finalize()
+        }
+    }
+}

--- a/src/specialized/mod.rs
+++ b/src/specialized/mod.rs
@@ -5,6 +5,9 @@ cfg_if! {
     ))] {
         mod pclmulqdq;
         pub use self::pclmulqdq::State;
+    } else if #[cfg(all(feature = "nightly", target_arch = "aarch64"))] {
+        mod aarch64;
+        pub use self::aarch64::State;
     } else {
         #[derive(Clone)]
         pub enum State {}


### PR DESCRIPTION
~~This should eventually be done using intrinsics, but~~

- ~~[core::arch::aarch64 doesn't have any crc32 intrinsics right now](https://doc.rust-lang.org/1.30.1/core/arch/aarch64/index.html)~~
- the intrinsic access is only stable for x86 anyway I think??

~~Ideally, CPU capabilities should be checked too, but `stdsimd` doesn't do that on FreeBSD on non-x86 CPUs (`elf_aux_info`) yet. (And all my machines run FreeBSD :D) CRC is mandatory in ARMv8.1 anyway, and there are *very* few v8.0 chips without it.~~

*see comments*

---

Some fun bench runs!

tfw a humble ARM Cortex-A72 @ 2.18GHz (Rockchip RK3399, `cpuset -l4-5`):

```
test bench_kilobyte_baseline    ... bench:       1,167 ns/iter (+/- 41) = 877 MB/s
test bench_kilobyte_specialized ... bench:          80 ns/iter (+/- 0) = 12800 MB/s
test bench_megabyte_baseline    ... bench:   1,201,396 ns/iter (+/- 10,942) = 872 MB/s
test bench_megabyte_specialized ... bench:     185,709 ns/iter (+/- 197,317) = 5646 MB/s
```

matches a Ryzen 7 1700 @ 3.85GHz (well, in one test)

```
test bench_kilobyte_baseline    ... bench:         301 ns/iter (+/- 1) = 3401 MB/s
test bench_kilobyte_specialized ... bench:          80 ns/iter (+/- 0) = 12800 MB/s
test bench_megabyte_baseline    ... bench:     302,681 ns/iter (+/- 710) = 3464 MB/s
test bench_megabyte_specialized ... bench:      73,559 ns/iter (+/- 168) = 14254 MB/s
```

while the Cortex-A53 (@ 1.6GHz, Rockchip RK3399, `cpuset -l0-3`) is *that* much worse than the A72:

```
test bench_kilobyte_baseline    ... bench:       1,922 ns/iter (+/- 52) = 532 MB/s
test bench_kilobyte_specialized ... bench:         229 ns/iter (+/- 0) = 4471 MB/s
test bench_megabyte_baseline    ... bench:   1,904,466 ns/iter (+/- 14,574) = 550 MB/s
test bench_megabyte_specialized ... bench:     563,171 ns/iter (+/- 10,137) = 1861 MB/s
```

and Cavium ThunderX (Scaleway's KVM VPS) has terrible CRC32 units in particular:

```
test bench_kilobyte_baseline    ... bench:       1,436 ns/iter (+/- 22) = 713 MB/s
test bench_kilobyte_specialized ... bench:         375 ns/iter (+/- 19) = 2730 MB/s
test bench_megabyte_baseline    ... bench:   2,332,481 ns/iter (+/- 618,310) = 449 MB/s
test bench_megabyte_specialized ... bench:     595,290 ns/iter (+/- 65,599) = 1761 MB/s
```

upd: my phone: Qualcomm Snapdragon 660 (Kryo V2, 2.2GHz, weird big.little management?):

```
test bench_kilobyte_baseline    ... bench:         916 ns/iter (+/- 19) = 1117 MB/s
test bench_kilobyte_specialized ... bench:         129 ns/iter (+/- 1) = 7937 MB/s
test bench_megabyte_baseline    ... bench:     951,838 ns/iter (+/- 28,575) = 1101 MB/s
test bench_megabyte_specialized ... bench:     124,165 ns/iter (+/- 4,731) = 8445 MB/s
```