### PR TITLE
make finalize() use a reference to make lib easier to use

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -14,7 +14,7 @@ impl State {
         self.state = update_fast_16(self.state, buf);
     }
 
-    pub fn finalize(self) -> u32 {
+    pub fn finalize(&self) -> u32 {
         self.state
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,10 +108,10 @@ impl Hasher {
     }
 
     /// Finalize the hash state and return the computed CRC32 value.
-    pub fn finalize(self) -> u32 {
+    pub fn finalize(&self) -> u32 {
         match self.state {
-            State::Baseline(state) => state.finalize(),
-            State::Specialized(state) => state.finalize(),
+            State::Baseline(ref state) => state.finalize(),
+            State::Specialized(ref state) => state.finalize(),
         }
     }
 

--- a/src/specialized/aarch64.rs
+++ b/src/specialized/aarch64.rs
@@ -22,7 +22,7 @@ impl State {
         self.state = unsafe { calculate(self.state, buf) }
     }
 
-    pub fn finalize(self) -> u32 {
+    pub fn finalize(&self) -> u32 {
         self.state
     }
 

--- a/src/specialized/mod.rs
+++ b/src/specialized/mod.rs
@@ -20,8 +20,8 @@ cfg_if! {
                 match *self {}
             }
 
-            pub fn finalize(self) -> u32 {
-                match self{}
+            pub fn finalize(&self) -> u32 {
+                match *self{}
             }
 
             pub fn reset(&mut self) {

--- a/src/specialized/pclmulqdq.rs
+++ b/src/specialized/pclmulqdq.rs
@@ -43,7 +43,7 @@ impl State {
         self.state = unsafe { calculate(self.state, buf) }
     }
 
-    pub fn finalize(self) -> u32 {
+    pub fn finalize(&self) -> u32 {
         self.state
     }
 


### PR DESCRIPTION
Attempting to plug this into image-png crate but ran into an issue

```
   --> src\decoder\stream.rs:242:35
    |
242 |                         let sum = self.current_chunk.0.finalize() as u32;
    |                                   ^^^^^^^^^^^^^^^^^^^^ cannot move out of borrowed content
```

This patch resolves this and should generally make the lib easier to use.