### PR TITLE
Raise MSRV to 1.31

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ cache:
 
 matrix:
   include:
-    - rust: 1.20.0
-    - rust: 1.27.0
+    - rust: 1.31.0
     - rust: stable
     - rust: beta
     - rust: nightly


### PR DESCRIPTION
The dependency `cfg-if` switched to Rust 2018 edition with version 0.1.10, released on 2019-09-24, and now requires Rust 1.31 to build. Since no issues were raised in the almost six months since then, simply update CI to test against the new minimum required version.

Noticed due to the CI failures on my last PR.