### PR TITLE
Update dev-dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
 
 matrix:
   include:
-    - rust: 1.31.0
+    - rust: 1.34.0
     - rust: stable
     - rust: beta
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ cfg-if = "0.1"
 
 [dev-dependencies]
 bencher = "0.1"
-quickcheck = { version = "0.6", default-features = false }
+quickcheck = { version = "0.9", default-features = false }
 rand = "0.4"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = "0.1"
 [dev-dependencies]
 bencher = "0.1"
 quickcheck = { version = "0.9", default-features = false }
-rand = "0.4"
+rand = "0.7"
 
 [features]
 default = ["std"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,7 +9,7 @@ use rand::Rng;
 
 fn bench(b: &mut Bencher, size: usize, hasher_init: Hasher) {
     let mut bytes = vec![0u8; size];
-    rand::thread_rng().fill_bytes(&mut bytes);
+    rand::thread_rng().fill(&mut bytes[..]);
 
     b.iter(|| {
         let mut hasher = hasher_init.clone();


### PR DESCRIPTION
This also adjusts the MSRV on CI to 1.34 as that's the documented minimum required for the new versions. 1.34 has been out for a full 1.5 years now and is available even on Debian Jessie.