### PR TITLE
Update to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "Fast, SIMD-accelerated CRC32 (IEEE) checksum computation"
 repository = "https://github.com/srijs/rust-crc32fast"
 readme = "README.md"
 keywords = ["checksum", "crc", "crc32", "simd", "fast"]
+edition = "2018"
 
 [dependencies]
 cfg-if = "1.0"

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,4 +1,4 @@
-use table::CRC32_TABLE;
+use crate::table::CRC32_TABLE;
 
 #[derive(Clone)]
 pub struct State {
@@ -23,7 +23,7 @@ impl State {
     }
 
     pub fn combine(&mut self, other: u32, amount: u64) {
-        self.state = ::combine::combine(self.state, other, amount);
+        self.state = crate::combine::combine(self.state, other, amount);
     }
 }
 
@@ -70,6 +70,8 @@ pub(crate) fn update_slow(prev: u32, buf: &[u8]) -> u32 {
 
 #[cfg(test)]
 mod test {
+    use quickcheck::quickcheck;
+
     #[test]
     fn slow() {
         assert_eq!(super::update_slow(0, b""), 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,15 +25,6 @@
 )]
 
 #[deny(missing_docs)]
-#[cfg(test)]
-#[macro_use]
-extern crate quickcheck;
-
-#[macro_use]
-extern crate cfg_if;
-
-#[cfg(feature = "std")]
-use std as core;
 
 use core::fmt;
 use core::hash;
@@ -159,6 +150,7 @@ impl hash::Hasher for Hasher {
 
 #[cfg(test)]
 mod test {
+    use quickcheck::quickcheck;
     use super::Hasher;
 
     quickcheck! {

--- a/src/specialized/aarch64.rs
+++ b/src/specialized/aarch64.rs
@@ -67,6 +67,8 @@ pub unsafe fn calculate(crc: u32, data: &[u8]) -> u32 {
 
 #[cfg(test)]
 mod test {
+    use quickcheck::quickcheck;
+
     quickcheck! {
         fn check_against_baseline(init: u32, chunks: Vec<(Vec<u8>, usize)>) -> bool {
             let mut baseline = super::super::super::baseline::State::new(init);

--- a/src/specialized/mod.rs
+++ b/src/specialized/mod.rs
@@ -1,3 +1,5 @@
+use cfg_if::cfg_if;
+
 cfg_if! {
     if #[cfg(all(
         crc32fast_stdarchx86,

--- a/src/specialized/pclmulqdq.rs
+++ b/src/specialized/pclmulqdq.rs
@@ -52,7 +52,7 @@ impl State {
     }
 
     pub fn combine(&mut self, other: u32, amount: u64) {
-        self.state = ::combine::combine(self.state, other, amount);
+        self.state = crate::combine::combine(self.state, other, amount);
     }
 }
 
@@ -94,7 +94,7 @@ pub unsafe fn calculate(crc: u32, mut data: &[u8]) -> u32 {
     // the fallback implementation as it's too much hassle and doesn't seem too
     // beneficial.
     if data.len() < 128 {
-        return ::baseline::update_fast_16(crc, data);
+        return crate::baseline::update_fast_16(crc, data);
     }
 
     // Step 1: fold by 4 loop
@@ -183,7 +183,7 @@ pub unsafe fn calculate(crc: u32, mut data: &[u8]) -> u32 {
     let c = arch::_mm_extract_epi32(arch::_mm_xor_si128(x, t2), 1) as u32;
 
     if !data.is_empty() {
-        ::baseline::update_fast_16(!c, data)
+        crate::baseline::update_fast_16(!c, data)
     } else {
         !c
     }
@@ -204,6 +204,8 @@ unsafe fn get(a: &mut &[u8]) -> arch::__m128i {
 
 #[cfg(test)]
 mod test {
+    use quickcheck::quickcheck;
+
     quickcheck! {
         fn check_against_baseline(init: u32, chunks: Vec<(Vec<u8>, usize)>) -> bool {
             let mut baseline = super::super::super::baseline::State::new(init);


### PR DESCRIPTION
Since the MSRV was recently raised we can do this now.

Not technically part of the 2018 upgrade but I've taken the opportunity to move the imports for `quickcheck` and `cfg_if` to where they are actually used, instead of importing them crate-wide.