### PR TITLE
Fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "Fast, SIMD-accelerated CRC32 (IEEE) checksum computation"
 repository = "https://github.com/srijs/rust-crc32fast"
 readme = "README.md"
 keywords = ["checksum", "crc", "crc32", "simd", "fast"]
+edition = "2018"
 
 [dependencies]
 cfg-if = "1.0"

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,4 +1,4 @@
-use table::CRC32_TABLE;
+use crate::table::CRC32_TABLE;
 
 #[derive(Clone)]
 pub struct State {
@@ -23,7 +23,7 @@ impl State {
     }
 
     pub fn combine(&mut self, other: u32, amount: u64) {
-        self.state = ::combine::combine(self.state, other, amount);
+        self.state = crate::combine::combine(self.state, other, amount);
     }
 }
 
@@ -70,6 +70,8 @@ pub(crate) fn update_slow(prev: u32, buf: &[u8]) -> u32 {
 
 #[cfg(test)]
 mod test {
+    use quickcheck::quickcheck;
+
     #[test]
     fn slow() {
         assert_eq!(super::update_slow(0, b""), 0);

--- a/src/combine.rs
+++ b/src/combine.rs
@@ -20,7 +20,6 @@ fn gf2_matrix_square(square: &mut [u32; GF2_DIM], mat: &[u32; GF2_DIM]) {
 }
 
 pub(crate) fn combine(mut crc1: u32, crc2: u32, mut len2: u64) -> u32 {
-    let mut row: u32;
     let mut even = [0u32; GF2_DIM]; /* even-power-of-two zeros operator */
     let mut odd = [0u32; GF2_DIM]; /* odd-power-of-two zeros operator */
 
@@ -31,10 +30,8 @@ pub(crate) fn combine(mut crc1: u32, crc2: u32, mut len2: u64) -> u32 {
 
     /* put operator for one zero bit in odd */
     odd[0] = 0xedb88320; /* CRC-32 polynomial */
-    row = 1;
-    for n in 1..GF2_DIM {
-        odd[n] = row;
-        row <<= 1;
+    for (i, odd_val) in odd[1..].iter_mut().enumerate() {
+       *odd_val = 1 << i;
     }
 
     /* put operator for two zero bits in even */

--- a/src/combine.rs
+++ b/src/combine.rs
@@ -24,8 +24,8 @@ pub(crate) fn combine(mut crc1: u32, crc2: u32, mut len2: u64) -> u32 {
     let mut even = [0u32; GF2_DIM]; /* even-power-of-two zeros operator */
     let mut odd = [0u32; GF2_DIM]; /* odd-power-of-two zeros operator */
 
-    /* degenerate case (also disallow negative lengths) */
-    if len2 <= 0 {
+    /* degenerate case */
+    if len2 == 0 {
         return crc1;
     }
 

--- a/src/combine.rs
+++ b/src/combine.rs
@@ -10,7 +10,7 @@ fn gf2_matrix_times(mat: &[u32; GF2_DIM], mut vec: u32) -> u32 {
         vec >>= 1;
         idx += 1;
     }
-    return sum;
+    sum
 }
 
 fn gf2_matrix_square(square: &mut [u32; GF2_DIM], mat: &[u32; GF2_DIM]) {
@@ -72,6 +72,5 @@ pub(crate) fn combine(mut crc1: u32, crc2: u32, mut len2: u64) -> u32 {
     }
 
     /* return combined crc */
-    crc1 ^= crc2;
-    return crc1;
+    crc1 ^ crc2
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
     feature(stdsimd, aarch64_target_feature)
 )]
 
-#[deny(missing_docs)]
+#![deny(missing_docs)]
 
 use core::fmt;
 use core::hash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,15 +25,6 @@
 )]
 
 #[deny(missing_docs)]
-#[cfg(test)]
-#[macro_use]
-extern crate quickcheck;
-
-#[macro_use]
-extern crate cfg_if;
-
-#[cfg(feature = "std")]
-use std as core;
 
 use core::fmt;
 use core::hash;
@@ -159,6 +150,7 @@ impl hash::Hasher for Hasher {
 
 #[cfg(test)]
 mod test {
+    use quickcheck::quickcheck;
     use super::Hasher;
 
     quickcheck! {

--- a/src/specialized/aarch64.rs
+++ b/src/specialized/aarch64.rs
@@ -67,6 +67,8 @@ pub unsafe fn calculate(crc: u32, data: &[u8]) -> u32 {
 
 #[cfg(test)]
 mod test {
+    use quickcheck::quickcheck;
+
     quickcheck! {
         fn check_against_baseline(init: u32, chunks: Vec<(Vec<u8>, usize)>) -> bool {
             let mut baseline = super::super::super::baseline::State::new(init);

--- a/src/specialized/mod.rs
+++ b/src/specialized/mod.rs
@@ -1,3 +1,5 @@
+use cfg_if::cfg_if;
+
 cfg_if! {
     if #[cfg(all(
         crc32fast_stdarchx86,

--- a/src/specialized/pclmulqdq.rs
+++ b/src/specialized/pclmulqdq.rs
@@ -52,7 +52,7 @@ impl State {
     }
 
     pub fn combine(&mut self, other: u32, amount: u64) {
-        self.state = ::combine::combine(self.state, other, amount);
+        self.state = crate::combine::combine(self.state, other, amount);
     }
 }
 
@@ -94,7 +94,7 @@ pub unsafe fn calculate(crc: u32, mut data: &[u8]) -> u32 {
     // the fallback implementation as it's too much hassle and doesn't seem too
     // beneficial.
     if data.len() < 128 {
-        return ::baseline::update_fast_16(crc, data);
+        return crate::baseline::update_fast_16(crc, data);
     }
 
     // Step 1: fold by 4 loop
@@ -183,7 +183,7 @@ pub unsafe fn calculate(crc: u32, mut data: &[u8]) -> u32 {
     let c = arch::_mm_extract_epi32(arch::_mm_xor_si128(x, t2), 1) as u32;
 
     if !data.is_empty() {
-        ::baseline::update_fast_16(!c, data)
+        crate::baseline::update_fast_16(!c, data)
     } else {
         !c
     }
@@ -204,6 +204,8 @@ unsafe fn get(a: &mut &[u8]) -> arch::__m128i {
 
 #[cfg(test)]
 mod test {
+    use quickcheck::quickcheck;
+
     quickcheck! {
         fn check_against_baseline(init: u32, chunks: Vec<(Vec<u8>, usize)>) -> bool {
             let mut baseline = super::super::super::baseline::State::new(init);

--- a/src/specialized/pclmulqdq.rs
+++ b/src/specialized/pclmulqdq.rs
@@ -61,7 +61,6 @@ const K2: i64 = 0x1c6e41596;
 const K3: i64 = 0x1751997d0;
 const K4: i64 = 0x0ccaa009e;
 const K5: i64 = 0x163cd6124;
-const K6: i64 = 0x1db710640;
 
 const P_X: i64 = 0x1DB710641;
 const U_PRIME: i64 = 0x1F7011641;
@@ -144,7 +143,6 @@ pub unsafe fn calculate(crc: u32, mut data: &[u8]) -> u32 {
     // It's not clear to me, reading the paper, where the xor operations are
     // happening or why things are shifting around. This implementation...
     // appears to work though!
-    drop(K6);
     let x = arch::_mm_xor_si128(
         arch::_mm_clmulepi64_si128(x, k3k4, 0x10),
         arch::_mm_srli_si128(x, 8),

--- a/src/specialized/pclmulqdq.rs
+++ b/src/specialized/pclmulqdq.rs
@@ -80,7 +80,7 @@ unsafe fn debug(s: &str, a: arch::__m128i) -> arch::__m128i {
         }
         println!();
     }
-    return a;
+    a
 }
 
 #[cfg(not(feature = "std"))]
@@ -199,7 +199,7 @@ unsafe fn get(a: &mut &[u8]) -> arch::__m128i {
     debug_assert!(a.len() >= 16);
     let r = arch::_mm_loadu_si128(a.as_ptr() as *const arch::__m128i);
     *a = &a[16..];
-    return r;
+    r
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This fixes most clippy warnings in this crate. Might want to make sure that `No need to check if a u64 is less than zero` and `Remove unused constant K6` are actually just removing remnants and aren't indications of real bugs.

Note that this is based on my earlier 2018 edition PR. I'll rebase once that gets merged.