### PR TITLE
Fix build for targets that don't support `sse2`, `sse4.2`, or `pclmulqdq` features

### DIFF
--- a/src/specialized/mod.rs
+++ b/src/specialized/mod.rs
@@ -1,6 +1,7 @@
 cfg_if! {
     if #[cfg(all(
         crc32fast_stdarchx86,
+        target_feature = "sse2", target_feature = "sse4.1", target_feature = "pclmulqdq",
         any(target_arch = "x86", target_arch = "x86_64")
     ))] {
         mod pclmulqdq;

--- a/src/specialized/mod.rs
+++ b/src/specialized/mod.rs
@@ -1,7 +1,7 @@
 cfg_if! {
     if #[cfg(all(
         crc32fast_stdarchx86,
-        target_feature = "sse2", target_feature = "sse4.1", target_feature = "pclmulqdq",
+        target_feature = "sse2",
         any(target_arch = "x86", target_arch = "x86_64")
     ))] {
         mod pclmulqdq;


### PR DESCRIPTION
The current `build.rs` script emits the `crc32fast_stdarchx86` cfg if the version of rustc is greater than 1.27, regardless of the underlying compilation target.

However, when building this crate for targets that don't support the `sse2`, `sse4.2`, and `pclmulqdq` features, the compiler will still emit SSE instructions. This causes one of two very strange problems:
* At build time, a cryptic LLVM error is thrown: `LLVM ERROR: Do not know how to split this operator's operand!`, which (I think) occurs because LLVM is not expecting to parse/emit SSE instructions when not configured to do so.
* At runtime, fatal CPU exceptions occur, e.g., a General Protection Fault or Invalid Opcode on x86, which will crash/hang the machine. This is particularly problematic for embedded systems and OS kernel environments.

This PR adds the correct feature gates to ensure that invalid instructions cannot be emitted, i.e., that SSE instructions are only used if the target machine supports them.

Related: the `memchr` crate already experienced this problem. Some related issues:
* https://github.com/rust-lang/rust/issues/61721
* https://github.com/BurntSushi/memchr/pull/77