### PR TITLE
Allow providing `amount` when creating Hasher from checksum.

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -21,19 +21,23 @@ fn bench(b: &mut Bencher, size: usize, hasher_init: Hasher) {
 }
 
 fn bench_kilobyte_baseline(b: &mut Bencher) {
-    bench(b, 1024, Hasher::internal_new_baseline(0))
+    bench(b, 1024, Hasher::internal_new_baseline(0, 0))
 }
 
 fn bench_kilobyte_specialized(b: &mut Bencher) {
-    bench(b, 1024, Hasher::internal_new_specialized(0).unwrap())
+    bench(b, 1024, Hasher::internal_new_specialized(0, 0).unwrap())
 }
 
 fn bench_megabyte_baseline(b: &mut Bencher) {
-    bench(b, 1024 * 1024, Hasher::internal_new_baseline(0))
+    bench(b, 1024 * 1024, Hasher::internal_new_baseline(0, 0))
 }
 
 fn bench_megabyte_specialized(b: &mut Bencher) {
-    bench(b, 1024 * 1024, Hasher::internal_new_specialized(0).unwrap())
+    bench(
+        b,
+        1024 * 1024,
+        Hasher::internal_new_specialized(0, 0).unwrap(),
+    )
 }
 
 benchmark_group!(

--- a/fuzz/src/main.rs
+++ b/fuzz/src/main.rs
@@ -5,7 +5,7 @@ extern crate crc32fast;
 use crc32fast::Hasher;
 
 fn main() {
-    let hasher_init = Hasher::internal_new_specialized().unwrap();
+    let hasher_init = Hasher::internal_new_specialized(0, 0).unwrap();
     fuzz!(|data: &[u8]| {
         let mut hasher = hasher_init.clone();
         hasher.update(data);


### PR DESCRIPTION
Given `crc(a)`, `crc(b)`, and `len(b)`, you can compute `crc(a || b)`.
The library already supports that via `combine`, but there is not
currently a way to create a `Hasher` with a non-zero `amount` and the
desired state without access to the original data.