### PR TITLE
Fix AArch64 build when the `nightly` feature is enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update $MSRV && rustup default $MSRV
+      - name: Downgrade some dependencies to their latest MSRV-compatible versions
+        run: |
+          cargo update -p ppv-lite86 --precise 0.2.17
+          cargo update -p libc --precise 0.2.163
       - name: Test in debug mode
         run: cargo test --no-fail-fast
       - name: Test in release mode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/srijs/rust-crc32fast"
 readme = "README.md"
 keywords = ["hash", "crc", "crc32", "simd", "fast"]
 categories = ["algorithms", "no-std"]
+rust-version = "1.46"
 
 [dependencies]
 cfg-if = "1.0"

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ Note: Because runtime CPU feature detection requires OS support, the specialized
 This feature flag enables unstable features that are only available on the `nightly` channel. Keep in mind that when enabling this feature flag, you
 might experience breaking changes when updating compiler versions.
 
-Currently, enabling this feature flag will make the optimized `aarch64` implementation available.
-
 ## License
 
 This project is licensed under either of

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,27 @@
+use std::{env, process::Command};
+
+fn main() {
+    if let Some(minor_version) = minor_rustc_version() {
+        // rustc 1.80 stabilized ARM CRC32 intrinsics:
+        // https://doc.rust-lang.org/nightly/core/arch/aarch64/fn.__crc32d.html
+        if minor_version >= 80 {
+            println!("cargo:rustc-cfg=stable_arm_crc32_intrinsics");
+            println!("cargo:rustc-check-cfg=cfg(stable_arm_crc32_intrinsics)");
+        }
+    }
+}
+
+fn minor_rustc_version() -> Option<u32> {
+    Command::new(env::var_os("RUSTC")?)
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|output| {
+            std::str::from_utf8(&output.stdout).ok().and_then(|output| {
+                output
+                    .split('.')
+                    .nth(1)
+                    .and_then(|minor_version| minor_version.parse().ok())
+            })
+        })
+}

--- a/src/specialized/mod.rs
+++ b/src/specialized/mod.rs
@@ -5,7 +5,7 @@ cfg_if! {
     ))] {
         mod pclmulqdq;
         pub use self::pclmulqdq::State;
-    } else if #[cfg(all(feature = "nightly", target_arch = "aarch64"))] {
+    } else if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
         pub use self::aarch64::State;
     } else {

--- a/src/specialized/mod.rs
+++ b/src/specialized/mod.rs
@@ -5,7 +5,7 @@ cfg_if! {
     ))] {
         mod pclmulqdq;
         pub use self::pclmulqdq::State;
-    } else if #[cfg(target_arch = "aarch64")] {
+    } else if #[cfg(all(stable_arm_crc32_intrinsics, target_arch = "aarch64"))] {
         mod aarch64;
         pub use self::aarch64::State;
     } else {


### PR DESCRIPTION
https://github.com/rust-lang/stdarch/pull/1573 stabilized the `stdarch_arm_crc32` feature, meaning that it's no longer necessary to enable it to get ARM CRC intrinsics, and doing so in the latest nightlies causes compile errors to happen:

![The described build error](https://github.com/srijs/rust-crc32fast/assets/7822554/fa7bd788-c7c9-48aa-9d9f-14fa7aaac12d)

Let's get rid of that removed unstable feature and update the documentation accordingly.