### PR TITLE
Fix new nightly compiler warning due to custom `cfg` directive

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,7 @@ use std::str;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rustc-check-cfg=cfg(crc32fast_stdarchx86)");
 
     let minor = match rustc_minor_version() {
         Some(n) => n,


### PR DESCRIPTION
The latest nightlies, and eventually Rust 1.80, ship changes to detect invalid `cfg`s. This project uses a custom `cfg` flag on its build script, so it causes a false-positive warning with these new checks. Let's add a new Cargo build directive, which is ignored by older Cargo versions, to silence that warning.

More information: https://blog.rust-lang.org/2024/05/06/check-cfg.html