### PR TITLE
Credit "the paper" from which the PCLMULQDQ specialization came from

### DIFF
--- a/src/specialized/pclmulqdq.rs
+++ b/src/specialized/pclmulqdq.rs
@@ -1,3 +1,12 @@
+//! Specialized checksum code for the x86 CPU architecture, based on the efficient algorithm described
+//! in the following whitepaper:
+//!
+//! Gopal, V., Ozturk, E., Guilford, J., Wolrich, G., Feghali, W., Dixon, M., & Karakoyunlu, D. (2009).
+//! _Fast CRC computation for generic polynomials using PCLMULQDQ instruction_. Intel.
+//! (Mirror link: <https://fossies.org/linux/zlib-ng/doc/crc-pclmulqdq.pdf>, accessed 2024-05-20)
+//!
+//! Throughout the code, this work is referred to as "the paper".
+
 #[cfg(target_arch = "x86")]
 use core::arch::x86 as arch;
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
While "Fast CRC computation for generic polynomials using PCLMULQDQ instruction" is a well-known paper in the realm of specialized CRC and compression algorithms for the x86 architecture that has seen widespread implementation, not everyone is aware of it, and it's nevertheless a good practice to cite the sources ideas and knowledge come from.

Let's add a comment to the `pclmulqdq` module citing the whitepaper, including a link to a mirror hosting its PDF, for easy access by prospective contributors and other interested parties.