### PR TITLE
Use `#[repr(C)]` so the offset of every union field is 0.

### DIFF
--- a/src/specialized/pclmulqdq.rs
+++ b/src/specialized/pclmulqdq.rs
@@ -77,6 +77,7 @@ const U_PRIME: i64 = 0x1F7011641;
 #[cfg(feature = "std")]
 unsafe fn debug(s: &str, a: arch::__m128i) -> arch::__m128i {
     if false {
+        #[repr(C)]
         union A {
             a: arch::__m128i,
             b: [u8; 16],


### PR DESCRIPTION
According to
https://rust-lang.github.io/unsafe-code-guidelines/layout/unions.html#unions-with-default-layout-reprrust "the default layout of Rust unions is, in general, unspecified" and "there are no general guarantees about the offset of the fields, [and] whether all fields have the same offset".

This commit explicitly annotates `union A` with `#[repr(C)]` so that both of its fields are at offset 0 - this ensures that transmuting one field into the other is valid.  This change is based on https://rust-lang.github.io/unsafe-code-guidelines/layout/unions.html#c-compatible-layout-repr-c which says that "the offset of every field is 0".