### PR TITLE
Don't override compile-time target features based on runtime probing

### DIFF
--- a/src/specialized/aarch64.rs
+++ b/src/specialized/aarch64.rs
@@ -19,7 +19,7 @@ impl State {
 
     #[cfg(feature = "std")]
     pub fn new(state: u32) -> Option<Self> {
-        if std::arch::is_aarch64_feature_detected!("crc") {
+        if cfg!(target_feature = "crc") && std::arch::is_aarch64_feature_detected!("crc") {
             // SAFETY: The conditions above ensure that all
             //         required instructions are supported by the CPU.
             Some(Self { state })

--- a/src/specialized/pclmulqdq.rs
+++ b/src/specialized/pclmulqdq.rs
@@ -34,7 +34,10 @@ impl State {
 
     #[cfg(feature = "std")]
     pub fn new(state: u32) -> Option<Self> {
-        if is_x86_feature_detected!("pclmulqdq")
+        if cfg!(target_feature = "pclmulqdq")
+            && cfg!(target_feature = "sse2")
+            && cfg!(target_feature = "sse4.1")
+            && is_x86_feature_detected!("pclmulqdq")
             && is_x86_feature_detected!("sse2")
             && is_x86_feature_detected!("sse4.1")
         {


### PR DESCRIPTION
This makes it possible for Cranelift on aarch64 to compile crates that use `zip` in build.rs (e.g., `utoipa-swagger-ui`) by `RUSTFLAGS="-C target-feature=-crc"`. Previously crc32fast would simply ignore this and try to use SIMD anyway.