### PR TITLE
Remove baseline impl if specialized impl is always 

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,36 @@
 use std::{env, process::Command};
 
+fn declare_cfg(cfg: &str) {
+    println!("cargo:rustc-cfg={}", cfg);
+    println!("cargo:rustc-check-cfg=cfg({})", cfg);
+}
+
 fn main() {
+    let target = std::env::var("TARGET").unwrap();
+    let target_arch = target.split_once("-").unwrap().0;
+    let target_features = std::env::var("CARGO_CFG_TARGET_FEATURE")
+        .unwrap_or_default();
+
+    if
+        (target_arch == "x86" || target_arch == "x86_64")
+        && target_features.contains("sse2")
+        && target_features.contains("pclmulqdq")
+        && target_features.contains("sse4.1")
+    {
+        declare_cfg("always_have_specialized");
+    }
+    
     if let Some(minor_version) = minor_rustc_version() {
         // rustc 1.80 stabilized ARM CRC32 intrinsics:
         // https://doc.rust-lang.org/nightly/core/arch/aarch64/fn.__crc32d.html
         if minor_version >= 80 {
-            println!("cargo:rustc-cfg=stable_arm_crc32_intrinsics");
-            println!("cargo:rustc-check-cfg=cfg(stable_arm_crc32_intrinsics)");
+            declare_cfg("stable_arm_crc32_intrinsics");
+
+            if target_arch == "aarch64"
+                && target_features.contains("crc")
+            {
+                declare_cfg("always_have_specialized");
+            }
         }
     }
 }

--- a/src/combine.rs
+++ b/src/combine.rs
@@ -40,16 +40,21 @@ pub(crate) fn combine(crc1: u32, crc2: u32, len2: u64) -> u32 {
     p ^ crc2
 }
 
-#[test]
-fn golden() {
-    assert_eq!(combine(0x0, 0x1, 0x0), 0x0);
-    assert_eq!(combine(0xc401f8c9, 0x00000000, 0x0), 0xc401f8c9);
-    assert_eq!(combine(0x7cba3d5e, 0xe7466d39, 0xb), 0x76365c4f);
-    assert_eq!(combine(0x576c62d6, 0x123256e1, 0x47), 0x579a636);
-    assert_eq!(combine(0x4f626f9a, 0x9e5ccbf5, 0xa59d), 0x98d43168);
-    assert_eq!(combine(0xa09b8a88, 0x815b0f48, 0x40f39511), 0xd7a5f79);
-    assert_eq!(
-        combine(0x7f6a4306, 0xbc929646, 0x828cde72b3e25301),
-        0xef922dda
-    );
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn golden() {
+        assert_eq!(combine(0x0, 0x1, 0x0), 0x0);
+        assert_eq!(combine(0xc401f8c9, 0x00000000, 0x0), 0xc401f8c9);
+        assert_eq!(combine(0x7cba3d5e, 0xe7466d39, 0xb), 0x76365c4f);
+        assert_eq!(combine(0x576c62d6, 0x123256e1, 0x47), 0x579a636);
+        assert_eq!(combine(0x4f626f9a, 0x9e5ccbf5, 0xa59d), 0x98d43168);
+        assert_eq!(combine(0xa09b8a88, 0x815b0f48, 0x40f39511), 0xd7a5f79);
+        assert_eq!(
+            combine(0x7f6a4306, 0xbc929646, 0x828cde72b3e25301),
+            0xef922dda
+        );
+    }
 }

--- a/src/specialized/aarch64.rs
+++ b/src/specialized/aarch64.rs
@@ -1,5 +1,7 @@
 use core::arch::aarch64 as arch;
 
+const HAS_CRC: bool = cfg!(target_feature = "crc");
+
 #[derive(Clone)]
 pub struct State {
     state: u32,
@@ -8,7 +10,7 @@ pub struct State {
 impl State {
     #[cfg(not(feature = "std"))]
     pub fn new(state: u32) -> Option<Self> {
-        if cfg!(target_feature = "crc") {
+        if HAS_CRC {
             // SAFETY: The conditions above ensure that all
             //         required instructions are supported by the CPU.
             Some(Self { state })
@@ -19,7 +21,7 @@ impl State {
 
     #[cfg(feature = "std")]
     pub fn new(state: u32) -> Option<Self> {
-        if std::arch::is_aarch64_feature_detected!("crc") {
+        if HAS_CRC || std::arch::is_aarch64_feature_detected!("crc") {
             // SAFETY: The conditions above ensure that all
             //         required instructions are supported by the CPU.
             Some(Self { state })

--- a/src/specialized/mod.rs
+++ b/src/specialized/mod.rs
@@ -8,7 +8,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(all(stable_arm_crc32_intrinsics, target_arch = "aarch64"))] {
         mod aarch64;
         pub use self::aarch64::State;
-    } else {
+    } else {      
         #[derive(Clone)]
         pub enum State {}
         impl State {

--- a/src/specialized/pclmulqdq.rs
+++ b/src/specialized/pclmulqdq.rs
@@ -12,6 +12,12 @@ use core::arch::x86 as arch;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64 as arch;
 
+const HAS_SSE: bool = cfg!(all(
+    target_feature = "pclmulqdq",
+    target_feature = "sse2",
+    target_feature = "sse4.1",
+));
+
 #[derive(Clone)]
 pub struct State {
     state: u32,
@@ -20,10 +26,7 @@ pub struct State {
 impl State {
     #[cfg(not(feature = "std"))]
     pub fn new(state: u32) -> Option<Self> {
-        if cfg!(target_feature = "pclmulqdq")
-            && cfg!(target_feature = "sse2")
-            && cfg!(target_feature = "sse4.1")
-        {
+        if HAS_SSE {
             // SAFETY: The conditions above ensure that all
             //         required instructions are supported by the CPU.
             Some(Self { state })
@@ -34,9 +37,12 @@ impl State {
 
     #[cfg(feature = "std")]
     pub fn new(state: u32) -> Option<Self> {
-        if is_x86_feature_detected!("pclmulqdq")
-            && is_x86_feature_detected!("sse2")
-            && is_x86_feature_detected!("sse4.1")
+        if HAS_SSE 
+            || (
+                is_x86_feature_detected!("pclmulqdq")
+                    && is_x86_feature_detected!("sse2")
+                    && is_x86_feature_detected!("sse4.1")
+            )
         {
             // SAFETY: The conditions above ensure that all
             //         required instructions are supported by the CPU.


### PR DESCRIPTION
That would remove mod baseline and table, and branches within Hasher that are never used.